### PR TITLE
Ajout de la section Utilisation via Docker dans le README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+# Définir le répertoire de travail
+WORKDIR /app
+
+# Copier le fichier des dépendances et les installer
+COPY requirements.txt ./
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+# Copier l'ensemble du projet dans le conteneur
+COPY . ./
+
+# Rendre le script principal exécutable
+RUN chmod +x crontask-helper/main.py
+
+# Définir le point d'entrée pour le conteneur
+ENTRYPOINT ["./crontask-helper/main.py"]
+
+# Par défaut, afficher l'aide
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Le script `main.py` constitue l'interface principale pour interagir avec l'agent
 *   `-p` ou `--prompt` : Instruction destinée à l'agent, par exemple "Génère une ligne de configuration cron". Cet argument spécifie la description en langage naturel de la tâche cron à générer.
 *   `-c` ou `--chronos-description` : Description temporelle de la tâche cron, par exemple "tous les jours à 7h". Cela permet de définir la planification de l'exécution.
 *   `-e` ou `--execute` : Commande à exécuter par la tâche cron, telle que `/bin/bash /opt/script.sh`. Si cet argument est omis, l'agent utilisera une commande par défaut ou sollicitera des précisions supplémentaires.
-*   `-m` ou `--model` : Nom du modèle Ollama à utiliser pour générer la configuration cron (défaut : `qwen2.5:0.5b`). Veillez à ce que ce modèle soit installé localement via Ollama.
+*   `-m` ou `--model` : Nom du modèle Ollama à utiliser pour générer la configuration cron (défaut : `llama3.2:3b`). Veillez à ce que ce modèle soit installé localement via Ollama.
 *   `-u` ou `--ollama_base_url` : URL de base du serveur Ollama (défaut : `http://localhost:11434`). Modifiez ce paramètre si votre serveur Ollama est accessible à une autre adresse.
 *   `-U` ou `--unload` : Flag indiquant que le modèle doit être déchargé de la mémoire après l'exécution du script, ce qui permet d'économiser des ressources système.
 
@@ -70,7 +70,7 @@ Si vous rencontrez des problèmes :
 
 1. Assurez-vous qu'Ollama est en cours d'exécution : `curl http://localhost:11434/api/tags`
 2. Vérifiez que le modèle spécifié est disponible : `ollama list`
-3. Si le modèle n'est pas disponible, téléchargez-le : `ollama pull qwen2.5:0.5b`
+3. Si le modèle n'est pas disponible, téléchargez-le : `ollama pull llama3.2:3b`
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ Pour plus de détails sur ces arguments, consultez la section d'argparsing dans 
 
 Voici quelques exemples d'utilisation pour illustrer comment configurer différentes tâches cron :
 
+### Utilisation via Docker
+
+Vous pouvez également utiliser Docker pour exécuter crontask-helper. Voici comment procéder :
+
+1. Construisez l'image Docker :
+   docker build -t crontask-helper .
+
+2. Lancez le conteneur (l'aide s'affiche par défaut) :
+   docker run --rm crontask-helper
+
+Si vous souhaitez lancer le conteneur avec des options spécifiques, ajoutez-les à la commande docker run, par exemple :
+   docker run --rm crontask-helper -p "Génère une configuration cron" -c "tous les jours à 7h" -e "/bin/bash /opt/script.sh"
+
+Assurez-vous d'avoir Docker installé et en fonctionnement sur votre système.
+
 ## Format des tâches cron
 
 Les tâches cron suivent un format standard avec 5 champs temporels suivis de la commande à exécuter :

--- a/crontask-helper/agents.py
+++ b/crontask-helper/agents.py
@@ -1,7 +1,6 @@
 #coding: utf-8
 
 import requests
-
 from typing import List
 from typing import Dict
 #from typing import Union

--- a/crontask-helper/agents.py
+++ b/crontask-helper/agents.py
@@ -57,7 +57,7 @@ def generate_response(
     if messages is None:
         messages = [{'role': 'user', 'content': f'{prompt}'}]
 
-    rprint(f'[italic yellow]Prompt:[/italic yellow] {messages[-1]["content"]}')
+    rprint(f'[italic yellow]Prompt:[/italic yellow] \n{messages[-1]["content"]}')
 
     try:
         response: ChatResponse = chat(
@@ -176,7 +176,7 @@ Ne répondez pas à la question, ne faite aucun commentaire, juste générez la 
         user_message += " pour exécuter une commande"
 
     if isinstance(chron_description, str):
-        user_message += f"\n\nDescription de temporelle de la tâche cron: {chron_description}"
+        user_message += f"\nDescription de temporelle de la tâche cron: {chron_description}"
 
     messages_list = [
         {'role': 'system', 'content': system_message},

--- a/crontask-helper/functions.py
+++ b/crontask-helper/functions.py
@@ -4,7 +4,7 @@
 
 #from typing import List
 #from typing import Dict
-from typing import Union
+#from typing import Union
 #from typing import Tuple
 from typing import Optional
 #from typing import Any

--- a/crontask-helper/main.py
+++ b/crontask-helper/main.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 #coding: utf-8
 
-#from ollama import generate
-#from ollama._types import Options
-#from ollama import ChatResponse
-#from ollama import chat
+__version__ = "0.1.1"
+__author__ = "@0x07cb"
+__description__ = "Assistant pour générer des tâches cron"
 
+from bdb import effective
 import sys
 from typing import Optional
 
@@ -24,13 +24,26 @@ def main(
 ):
     """
     Fonction principale qui gère l'interaction avec l'agent crontask
-    
+
+    Cette fonction effective les étapes suivantes :
+    1. Vérifie la connectivité avec le serveur Ollama
+    2. Appelle l'agent pour générer une configuration de tâche cron
+    3. Affiche le résultat final
+    4. Gère les erreurs et interruptions
+    5. Décharge optionnellement le modèle de la mémoire
+
     Args:
-        prompt: Description de la tâche cron à générer
-        execute: Commande à exécuter dans la tâche cron
-        model: Modèle Ollama à utiliser
-        ollama_base_url: URL de base du serveur Ollama
-        unload: Si True, décharge le modèle après utilisation
+        prompt (Optional[str]): Instruction pour l'agent, décrivant la tâche cron à générer
+        chron_description (Optional[str]): Description temporelle de la tâche cron 
+        execute (Optional[str]): Commande spécifique à exécuter dans la tâche cron
+        model (Optional[str]): Modèle Ollama à utiliser pour la génération (défaut: "llama3.2:3b")
+        ollama_base_url (Optional[str]): URL du serveur Ollama (défaut: "http://localhost:11434")
+        unload (Optional[bool]): Indicateur pour décharger le modèle après utilisation
+
+    Raises:
+        requests.exceptions.RequestException: Si la connexion à Ollama échoue
+        KeyboardInterrupt: Si l'utilisateur interrompt l'exécution
+        Exception: Pour toute autre erreur inattendue
     """
     try:
         # Vérifier si Ollama est accessible
@@ -69,10 +82,24 @@ def main(
             except Exception as e:
                 rprint(f"[bold red]Erreur[/bold red]: [underline]Lors du déchargement du modèle[/underline]: {e}")
 
+
+def usage():
+    rprint(f"[bold cyan]Usage:[/bold cyan] [green]crontask-helper[/green] [yellow][options][/yellow]")
+    rprint(f"[bold white]Options:[/bold white]")
+    rprint(f"  [blue]-p[/blue], [blue]--prompt[/blue] <[magenta]prompt[/magenta]>    [white]Instruction pour l'agent[/white] [dim](ex: \"[italic]Génère une ligne de configuration cron[/italic]\")")
+    rprint(f"  [blue]-c[/blue], [blue]--chronos-description[/blue] <[magenta]description[/magenta]>    [white]Description temporelle de la tâche cron[/white] [dim](ex: \"[italic]tous les jours à 7h[/italic]\")")
+    rprint(f"  [blue]-e[/blue], [blue]--execute[/blue] <[magenta]commande[/magenta]>    [white]Commande à exécuter dans la tâche cron[/white] [dim](ex: \"[italic]/bin/bash /opt/script.sh[/italic]\")")
+    rprint(f"  [blue]-m[/blue], [blue]--model[/blue] <[magenta]model[/magenta]>    [white]Modèle Ollama à utiliser[/white] [dim](défaut: [italic]llama3.2:3b[/italic])")
+    rprint(f"  [blue]-u[/blue], [blue]--ollama-base-url[/blue] <[magenta]url[/magenta]>    [white]URL de base du serveur Ollama[/white] [dim](défaut: [italic]http://localhost:11434[/italic])")
+    rprint(f"  [blue]-U[/blue], [blue]--unload[/blue]    [white]Décharger le modèle après utilisation[/white]")
+
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description='CronTask Helper - Assistant pour générer des tâches cron')
+    parser = argparse.ArgumentParser(prog=f"crontask-helper v{__version__}",
+                                     description='CronTask Helper - Assistant pour générer des tâches cron'
+                                     )
+    
     parser.add_argument('-p', '--prompt', type=str, default=None, 
                         help='Instruction pour l\'agent (ex: "Génère une ligne de configuration cron")')
     parser.add_argument('-c', '--chronos-description', type=str, default=None, 


### PR DESCRIPTION
Cette PR introduit une nouvelle section dans le README.md décrivant comment construire l'image Docker et lancer le conteneur pour crontask-helper.  
  
Les instructions détaillent :

- La construction de l'image Docker avec la commande :  
  docker build -t crontask-helper .

- Le lancement du conteneur avec la commande :  
  docker run --rm crontask-helper

- Un exemple d'utilisation avec options supplémentaires pour configurer une tâche cron via Docker.

Ces ajouts visent à simplifier la prise en main du projet pour les utilisateurs préférant une solution containerisée.  
Merci de votre relecture.
